### PR TITLE
Implement wrapper_getenv; use TMPDIR in wrapper_tmpfile

### DIFF
--- a/libc_impl.c
+++ b/libc_impl.c
@@ -2180,8 +2180,15 @@ int wrapper_pathconf(uint8_t *mem, uint32_t path_addr, int name) {
 }
 
 uint32_t wrapper_getenv(uint8_t *mem, uint32_t name_addr) {
-    // Return null for everything, for now
-    return 0;
+    STRING(name);
+    char *value = getenv(name);
+    if (value == NULL) {
+        return 0;
+    }
+    size_t value_size = strlen(value) + 1;
+    uint32_t buf_addr = wrapper_malloc(mem, value_size);
+    strcpy1(mem, buf_addr, value);
+    return buf_addr;
 }
 
 uint32_t wrapper_gettxt(uint8_t *mem, uint32_t msgid_addr, uint32_t default_str_addr) {

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -2181,7 +2181,7 @@ int wrapper_pathconf(uint8_t *mem, uint32_t path_addr, int name) {
 
 uint32_t wrapper_getenv(uint8_t *mem, uint32_t name_addr) {
     STRING(name);
-    char *value = getenv(name);
+    const char *value = getenv(name);
     if (value == NULL) {
         return 0;
     }


### PR DESCRIPTION
Implementing `wrapper_getenv` lets the invoker configure `TOOLROOT` and `TMPDIR` (and some other things). These env vars make it easier to run the compiler in a sandbox environment (in particular: `nsjail`-in-Docker, where `/proc` is not mounted, so `/proc/self/exe` is not available). Not showstopping, but these changes make it easier to integrate.

I couldn't fully test my change to `wrapper_tmpfile`. It seems to be only have 1 callsite (in `cfe`), but in my testing I couldn't get it to be called. I tested the `getenv`/`snprintf` part in another function and it seemed to do the right thing.

I recompiled IDO 5.3 & 7.1 and successfully used them to rebuild a matching OOT.