### PR TITLE
Add support for ARM macs (apple silicon)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,14 @@ jobs:
           
       - name: Run the build script
         shell: bash
+        if: matrix.os != 'macos-latest'
         run: |
           python3 build.py ido/${{ matrix.ido }} -O2
+      - name: Run the build script (MacOS)
+        shell: bash
+        if: matrix.os == 'macos-latest'
+        run: |
+          python3 build.py ido/${{ matrix.ido }} -O2 -universal
       - name: Create release archive
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Create release archive
         shell: bash
         run: |
-          cd build${{ matrix.ido }}/out
+          cd build/${{ matrix.ido }}/out
           tar -czvf ../../ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz *
       - name: Upload archive
         uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 build5.3/
 build7.1/
-.vscode/
+build/

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ endif
 
 # --- Functions
 # fn irix_binary(ToolName) -> PathToOriginalTool
-#     all binaries are in usr/lib expect for cc which is in usr/bin 
+#     all binaries are in usr/lib except for cc which is in usr/bin 
 irix_binary = $(IRIX_USR_DIR)/$(if $(filter cc,$(1)),bin,lib)/$(1)
 
 # fn translated_src(ToolName) -> PathToOutputCFile

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ MACOS_FAT_TARGETS ?= arm64-apple-macos11 x86_64-apple-macos10.14
 
 # -- Build Directories
 BUILD_BASE ?= build
-BUILD_DIR  := $(BUILD_BASE)/$(IDO_VERSION)
-BUILT_BIN  := $(BUILD_DIR)/bin
+BUILD_DIR  := $(BUILD_BASE)/$(VERSION)
+BUILT_BIN  := $(BUILD_DIR)/out
 
 # -- Location of original IDO binaries
 IRIX_BASE    ?= ido

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,28 @@ else
   $(error Unknown or unsupported IDO version - $(VERSION))
 endif
 
+# -- determine the host environment and target
+# | Host  | Targets           |
+# |-------|-------------------|
+# | macOS | native, universal |
+# | linux | native            |
+#
+UNAME_S := $(shell uname -s)
+UNAME_P := $(shell uname -p)
+ifeq ($(UNAME_S),Darwin)
+  HOST_OS := macOS
+  TARGET  ?= native
+else ifeq ($(UNAME_S),Linux)
+  HOST_OS := linux
+  TARGET  := native
+else
+  $(error Unsupported host OS for Makefile)
+endif
+
+HOST_TARGET := $(HOST_OS)-$(TARGET)
+# clang build targets for ARM and x64 macOS
+MACOS_FAT_TARGETS ?= arm64-apple-macos11 x86_64-apple-macos10.14
+
 # -- Build Directories
 BUILD_BASE ?= build
 BUILD_DIR  := $(BUILD_BASE)/$(IDO_VERSION)
@@ -29,7 +51,12 @@ ERR_STRS_DST := $(BUILT_BIN)/err.english.cc
 
 # -- ensure build directories exist before compiling anything
 ifeq ($(filter clean,$(MAKECMDGOALS)),)
-  DUMMY != mkdir -p $(BUILD_BASE) $(BUILD_DIR) $(BUILT_BIN)
+  ALL_DIRS := $(BUILD_BASE) $(BUILD_DIR) $(BUILT_BIN)
+  ifeq ($(HOST_TARGET),macOS-universal)
+    ALL_DIRS += $(foreach target,$(MACOS_FAT_TARGETS),$(BUILD_DIR)/$(target))
+  endif
+
+  DUMMY != mkdir -p $(ALL_DIRS)
 endif
 
 # -- Settings for the static recompilation tool `recomp`
@@ -37,22 +64,24 @@ RECOMP       := $(BUILD_BASE)/recomp
 RECOMP_OPT   ?= -O2
 RECOMP_FLAGS ?= -std=c++11 -Wno-switch `pkg-config --cflags --libs capstone`
 
-
 # -- Settings for libc shim
-LIBC_SHIM  := $(BUILD_DIR)/libc_impl.o
+LIBC_IMPL := libc_impl.c
+LIBC_OBJ  := $(LIBC_IMPL:.c=.o)
 LIBC_OPT   ?= -O2
-LIBC_FLAGS ?= -fno-strict-aliasing
+LIBC_FLAGS ?= -fno-strict-aliasing 
 
 # -- Settings for recompiling the translated irix binaries
 COMPILE_OPT   ?= -O2
 COMPILE_FLAGS ?= -Wno-tautological-compare -fno-strict-aliasing -lm
-COMPILE_DEPS  := header.h helpers.h $(LIBC_SHIM) $(ERR_STRS_DST)
+COMPILE_DEPS  := header.h helpers.h $(ERR_STRS_DST)
 
 # -- Host specific configuration
-ifeq ($(shell uname -s),Darwin)
+ifeq ($(HOST_OS),macOS)
   # macOS clang wants `-fno-pie` on intel, but that flag is ignored on ARM
-  ifneq ($(shell uname -p),arm)
+  ifeq (,$(findstring arm,$(UNAME_P)))
+  ifneq (TARGET,universal)
     COMPILE_FLAGS += -fno-pie
+  endif
   endif
   # macOS has deprecated some libc functions that the 1992 irix binaries use
   LIBC_FLAGS += -Wno-deprecated-declarations
@@ -71,14 +100,40 @@ translated_src = $(BUILD_DIR)/$(1).c
 # fn recompiled_binary(ToolName) -> PathToOutputBin
 recompiled_binary = $(BUILT_BIN)/$(1)
 
-# fn recomple(ToolName) -> MakeRules
+# fn recomple(ToolName, LibcObj) -> MakeRules
 define recompile
 $(call translated_src,$1): $(call irix_binary,$1) $(RECOMP)
 	$(RECOMP) $(CONSERVATIVE_$1) $$< > $$@
 
-$(call recompiled_binary,$1): $(call translated_src,$1) $(COMPILE_DEPS)
-	$$(CC) $(LIBC_SHIM) $$< -o $$@ -I. $(COMPILE_OPT) $(COMPILE_FLAGS)
+$(call recompiled_binary,$1): $(call translated_src,$1) $(COMPILE_DEPS) $2
+	$$(CC) $2 $$< -o $$@ -I. $(COMPILE_OPT) $(COMPILE_FLAGS)
 endef
+
+# fn target_specific(ClangTarget, Artifact) -> Path
+target_specific = $(BUILD_DIR)/$1/$2
+
+# fn target_libc(ClangTarget) -> MakeRules
+define target_libc
+$(call target_specific,$1,$(LIBC_OBJ)): $(LIBC_IMPL) $(LIBC_IMPL:.c=.h)
+	$$(CC) $$< -c $(LIBC_OPT) $(LIBC_FLAGS) -target $1 -D$(IDO_VERSION) -o $$@
+endef
+# fn target_tool(ClangTarget, ToolName) -> MakeRules
+define target_tool
+$(call target_specific,$1,$2): $(call translated_src,$2) $(COMPILE_DEPS) $(call target_specific,$1,$(LIBC_OBJ))
+	$$(CC) $(call target_specific,$1,$(LIBC_OBJ)) $$< -o $$@ -I. $(COMPILE_OPT) $(COMPILE_FLAGS) $(if $(findstring x86,$1),-fno-pie) -target $1
+endef
+
+# fn recompile_universal(ToolName) -> MakeRules
+define recompile_universal
+$(call translated_src,$1): $(call irix_binary,$1) $(RECOMP)
+	$(RECOMP) $(CONSERVATIVE_$1) $$< > $$@
+
+$(foreach target,$(MACOS_FAT_TARGETS),$(eval $(call target_tool,$(target),$1)))
+
+$(call recompiled_binary,$1): $(foreach target,$(MACOS_FAT_TARGETS),$(BUILD_DIR)/$(target)/$1)
+	lipo -create -output $$@ $$^
+endef
+
 
 # --- Recipes
 ALL_TOOLS := $(foreach tool,$(IDO_TC),$(call recompiled_binary,$(tool)))
@@ -91,14 +146,23 @@ clean:
 $(RECOMP): recomp.cpp elf.h
 	$(CXX) $< -o $@ $(RECOMP_OPT) $(RECOMP_FLAGS)
 
-$(LIBC_SHIM): libc_impl.c libc_impl.h
-	$(CC) $< -c $(LIBC_FLAGS) $(LIBC_OPT) -D$(IDO_VERSION) -o $@
-
 $(ERR_STRS_DST): $(ERR_STRS_SRC)
 	cp $^ $@
 
-$(foreach tool,$(IDO_TC),$(eval $(call recompile,$(tool))))
+ifeq ($(HOST_TARGET),macOS-universal)
 
+$(foreach target,$(MACOS_FAT_TARGETS),$(eval $(call target_libc,$(target))))
+$(foreach tool,$(IDO_TC),$(eval $(call recompile_universal,$(tool))))
+
+else 
+
+LIBC_SHIM := $(BUILD_DIR)/$(LIBC_OBJ)
+$(LIBC_SHIM): $(LIBC_IMPL) $(LIBC_IMPL:.c=.h)
+	$(CC) $< -c $(LIBC_FLAGS) $(LIBC_OPT) -D$(IDO_VERSION) -o $@
+
+$(foreach tool,$(IDO_TC),$(eval $(call recompile,$(tool),$(LIBC_SHIM))))
+
+endif
 
 .PHONY: all clean
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,110 @@
+# --- Configuration
+# -- select the version and binaries of IDO toolchain to recompile
+VERSION ?= 7.1
+ifeq ($(VERSION),7.1)
+  IDO_VERSION := IDO71
+  IDO_TC      := cc as1 cfe ugen umerge uopt
+else ifeq ($(VERSION),5.3)
+  IDO_VERSION := IDO53
+  IDO_TC      := cc acpp as0 as1 cfe copt ugen ujoin uld umerge uopt usplit
+  # 5.3 ugen relies on UB stack reads
+  # to emulate, pass the conservative flag to `recomp`
+  CONSERVATIVE_ugen := --conservative
+else
+  $(error Unknown or unsupported IDO version - $(VERSION))
+endif
+
+# -- Build Directories
+BUILD_BASE ?= build
+BUILD_DIR  := $(BUILD_BASE)/$(IDO_VERSION)
+BUILT_BIN  := $(BUILD_DIR)/bin
+
+# -- Location of original IDO binaries
+IRIX_BASE    ?= ido
+IRIX_USR_DIR ?= $(IRIX_BASE)/$(VERSION)/usr
+
+# -- Location of the irix tool chain error messages
+ERR_STRS_SRC := $(IRIX_USR_DIR)/lib/err.english.cc
+ERR_STRS_DST := $(BUILT_BIN)/err.english.cc
+
+# -- ensure build directories exist before compiling anything
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
+  DUMMY != mkdir -p $(BUILD_BASE) $(BUILD_DIR) $(BUILT_BIN)
+endif
+
+# -- Settings for the static recompilation tool `recomp`
+RECOMP       := $(BUILD_BASE)/recomp
+RECOMP_OPT   ?= -O2
+RECOMP_FLAGS ?= -std=c++11 -Wno-switch `pkg-config --cflags --libs capstone`
+
+
+# -- Settings for libc shim
+LIBC_SHIM  := $(BUILD_DIR)/libc_impl.o
+LIBC_OPT   ?= -O2
+LIBC_FLAGS ?= -fno-strict-aliasing
+
+# -- Settings for recompiling the translated irix binaries
+COMPILE_OPT   ?= -O2
+COMPILE_FLAGS ?= -Wno-tautological-compare -fno-strict-aliasing -lm
+COMPILE_DEPS  := header.h helpers.h $(LIBC_SHIM) $(ERR_STRS_DST)
+
+# -- Host specific configuration
+ifeq ($(shell uname -s),Darwin)
+  # macOS clang wants `-fno-pie` on intel, but that flag is ignored on ARM
+  ifneq ($(shell uname -p),arm)
+    COMPILE_FLAGS += -fno-pie
+  endif
+  # macOS has deprecated some libc functions that the 1992 irix binaries use
+  LIBC_FLAGS += -Wno-deprecated-declarations
+else
+  COMPILE_FLAGS += -no-pie
+endif
+
+# --- Functions
+# fn irix_binary(ToolName) -> PathToOriginalTool
+#     all binaries are in usr/lib expect for cc which is in usr/bin 
+irix_binary = $(IRIX_USR_DIR)/$(if $(filter cc,$(1)),bin,lib)/$(1)
+
+# fn translated_src(ToolName) -> PathToOutputCFile
+translated_src = $(BUILD_DIR)/$(1).c
+
+# fn recompiled_binary(ToolName) -> PathToOutputBin
+recompiled_binary = $(BUILT_BIN)/$(1)
+
+# fn recomple(ToolName) -> MakeRules
+define recompile
+$(call translated_src,$1): $(call irix_binary,$1) $(RECOMP)
+	$(RECOMP) $(CONSERVATIVE_$1) $$< > $$@
+
+$(call recompiled_binary,$1): $(call translated_src,$1) $(COMPILE_DEPS)
+	$$(CC) $(LIBC_SHIM) $$< -o $$@ -I. $(COMPILE_OPT) $(COMPILE_FLAGS)
+endef
+
+# --- Recipes
+ALL_TOOLS := $(foreach tool,$(IDO_TC),$(call recompiled_binary,$(tool)))
+
+all: $(ALL_TOOLS)
+
+clean:
+	$(RM) -rf $(BUILD_BASE)
+
+$(RECOMP): recomp.cpp elf.h
+	$(CXX) $< -o $@ $(RECOMP_OPT) $(RECOMP_FLAGS)
+
+$(LIBC_SHIM): libc_impl.c libc_impl.h
+	$(CC) $< -c $(LIBC_FLAGS) $(LIBC_OPT) -D$(IDO_VERSION) -o $@
+
+$(ERR_STRS_DST): $(ERR_STRS_SRC)
+	cp $^ $@
+
+$(foreach tool,$(IDO_TC),$(eval $(call recompile,$(tool))))
+
+
+.PHONY: all clean
+
+# Remove built-in rules, to improve performance
+MAKEFLAGS += --no-builtin-rules
+
+# --- Debugging
+# run `make print-VARIABLE` to debug that variable
+print-% : ; $(info $* is a $(flavor $*) variable set to [$($*)]) @true

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Likewise, the `make` dependency is only needed if building with `make`.
 
 ## Linux (Debian / Ubuntu)
 ```bash
-sudo apt-get install build-essential libcapstone-dev pkg-config python3
+sudo apt-get install build-essential libcapstone3 pkg-config python3
 ```
 
 ## macOS
@@ -21,35 +21,39 @@ sudo apt-get install build-essential libcapstone-dev pkg-config python3
 ```bash
 brew install make python3 pkg-config capstone
 ```
-Use `gmake` instead of `make` in order to use homebrew's `make`
+When building, use `gmake` instead of `make` in order to use homebrew's `make`
 
-## Build using Make
+# Build using Make
 ```bash
 make VERSION=5.3
 make VERSION=7.1
 ```
-The build artifacts are located in `build/{IDO71|IDO53}/bin`
+The build artifacts are located in `build/{7.1|5.3}/out`.
 
-## Build using Python3
+# Build using Python3
 Using `build.py`
 ```bash
 ./build.py -O2 ido/5.3
 ./build.py -O2 ido/7.1
 ```
-The build artifacts are located in `{build7.1|build5.3}/out`
+The build artifacts are located in `build/{7.1|5.3}/out`. For more options, run `./build.py --help`.
 
-## Manual Building
+## Creating Universal ARM/x86_64 macOS Builds
+By default, the python and make build script create native binaries on macOS. This was done to minimize the time to build the recompiled suite.
+In order to create "fat," universal ARM and x86_64, pass the `-universal` flag to `build.py`, or `TARGET=universal` to `gmake`.
+
+# Manual Building
 
 Example for compiling `as1` in a Linux environment:
 
 ```
-1. g++ recomp.cpp -o recomp -g -lcapstone
-2. ./recomp ~/ido7.1_compiler/usr/lib/as1 > as1_c.c
-3. gcc libc_impl.c as1_c.c -o as1 -g -fno-strict-aliasing -lm -no-pie -DIDO71
+g++ recomp.cpp -o recomp -g -lcapstone
+./recomp ~/ido7.1_compiler/usr/lib/as1 > as1_c.c
+gcc libc_impl.c as1_c.c -o as1 -g -fno-strict-aliasing -lm -no-pie -DIDO71
 ```
 
 Use the same approach for `cc`, `cfe`, `uopt`, `ugen`, `as1` (and `copt` if you need that).
 
 Use `-DIDO53` instead of `-DIDO71` if the program you are trying to recompile was compiled with IDO 5.3 rather than IDO 7.1.
 
-You can add `-O2` to step 3. To compile ugen for IDO 5.3, add `--conservative` after `./recomp` in step 2. This mimics UB present in `ugen53`. That program reads uninitialized stack memory and its result depends on that stack memory.
+You can add `-O2` to step 3. To compile `ugen` for IDO 5.3, add `--conservative` after `./recomp` in step 2. This mimics UB present in `ugen53`. That program reads uninitialized stack memory and its result depends on that stack memory.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,46 @@
-# Static recomp of IRIX programs
+# Static Recompilation of IRIX Programs
+Convert selected IRIX C toolchain programs into modern Linux or macOS programs
 
-Example for compiling `as1`:
+## Supported Programs
+* IDO 5.3
+  * cc, acpp, as0, as1, cfe, copt, ugen, ujoin, uld, umerge, uopt, usplit
+* IDO 7.1
+  * cc, as1, cfe, ugen, umerge, uopt
+
+# Dependencies
+Note that the `python3` dependency is only necessary if building with the `build.py` script. 
+Likewise, the `make` dependency is only needed if building with `make`.
+
+## Linux (Debian / Ubuntu)
+```bash
+sudo apt-get install build-essential libcapstone-dev pkg-config python3
+```
+
+## macOS
+[Install homebrew](https://brew.sh/) and then:
+```bash
+brew install make python3 pkg-config capstone
+```
+Use `gmake` instead of `make` in order to use homebrew's `make`
+
+## Build using Make
+```bash
+make VERSION=5.3
+make VERSION=7.1
+```
+The build artifacts are located in `build/{IDO71|IDO53}/bin`
+
+## Build using Python3
+Using `build.py`
+```bash
+./build.py -O2 ido/5.3
+./build.py -O2 ido/7.1
+```
+The build artifacts are located in `{build7.1|build5.3}/out`
+
+## Manual Building
+
+Example for compiling `as1` in a Linux environment:
 
 ```
 1. g++ recomp.cpp -o recomp -g -lcapstone
@@ -12,4 +52,4 @@ Use the same approach for `cc`, `cfe`, `uopt`, `ugen`, `as1` (and `copt` if you 
 
 Use `-DIDO53` instead of `-DIDO71` if the program you are trying to recompile was compiled with IDO 5.3 rather than IDO 7.1.
 
-You can add `-O2` to step 3. To compile ugen for IDO 5.3, add `-Dugen53` to step 1, which makes it more conservative due to ugen53 reads uninitialized stack memory and the result depends on that.
+You can add `-O2` to step 3. To compile ugen for IDO 5.3, add `--conservative` after `./recomp` in step 2. This mimics UB present in `ugen53`. That program reads uninitialized stack memory and its result depends on that stack memory.

--- a/build.py
+++ b/build.py
@@ -59,7 +59,9 @@ def process_prog(prog, ido_path, ido_flag, fix_ugen, build_dir, out_dir, args, r
     flags = " -Wno-tautological-compare -fno-strict-aliasing -lm"
 
     if platform.system() == "Darwin":
-        flags += " -fno-pie -Wno-deprecated-declarations"
+        flags += " -Wno-deprecated-declarations"
+        if "arm" not in platform.processor():
+            flags += " -fno-pie"
     else:
         flags += " -g -no-pie"
 

--- a/build.py
+++ b/build.py
@@ -3,64 +3,87 @@ import argparse
 import subprocess
 import os
 import sys
-import re
 import platform
 import threading
 import shutil
+from pathlib import Path
 
 BINS = {
     "5.3": [
-        "/usr/bin/cc",
-        "/usr/lib/acpp",
-        "/usr/lib/as0",
-        "/usr/lib/as1",
-        "/usr/lib/cfe",
-        "/usr/lib/copt",
-        "/usr/lib/ugen",
-        "/usr/lib/ujoin",
-        "/usr/lib/uld",
-        "/usr/lib/umerge",
-        "/usr/lib/uopt",
-        "/usr/lib/usplit",
+        "usr/bin/cc",
+        "usr/lib/acpp",
+        "usr/lib/as0",
+        "usr/lib/as1",
+        "usr/lib/cfe",
+        "usr/lib/copt",
+        "usr/lib/ugen",
+        "usr/lib/ujoin",
+        "usr/lib/uld",
+        "usr/lib/umerge",
+        "usr/lib/uopt",
+        "usr/lib/usplit",
     ],
     "7.1": [
-        "/usr/bin/cc",
-        "/usr/lib/as1",
-        "/usr/lib/cfe",
-        "/usr/lib/ugen",
-        "/usr/lib/umerge",
-        "/usr/lib/uopt",
+        "usr/bin/cc",
+        "usr/lib/as1",
+        "usr/lib/cfe",
+        "usr/lib/ugen",
+        "usr/lib/umerge",
+        "usr/lib/uopt",
     ]
 }
 
+MACOS_TARGETS = [
+    "arm64-apple-macos11", 
+    "x86_64-apple-macos10.14"
+]
 
-def call(args, output_file=None):
-    print(args)
+class Colors:
+    NO_COL = "\033[0m"
+    RED    = "\033[0;31m"
+    GREEN  = "\033[0;32m"
+    BLUE   = "\033[0;34m"
+    YELLOW = "\033[0;33m"
+
+    def disable(self):
+        self.NO_COL = ""
+        self.RED    = ""
+        self.GREEN  = ""
+        self.BLUE   = ""
+        self.YELLOW = ""
+
+COLORS = Colors()
+
+def print_step(cmd, input, output, rev=False):
+    if rev:
+        print(f"{COLORS.GREEN}{cmd}\t{COLORS.BLUE}{output}{COLORS.GREEN} <- {COLORS.YELLOW}{input}{COLORS.NO_COL}")
+    else:
+        print(f"{COLORS.GREEN}{cmd}\t{COLORS.YELLOW}{input}{COLORS.GREEN} -> {COLORS.BLUE}{output}{COLORS.NO_COL}")
+
+def call(args, output_file=None, verbose=False):
+    if verbose:
+        print(args)
+
     p = subprocess.Popen(args, shell=True, universal_newlines=True, stdout=output_file)
     p.wait()
     if output_file:
         output_file.flush()
 
-def process_prog(prog, ido_path, ido_flag, fix_ugen, build_dir, out_dir, args, recomp_path):
-    print("Recompiling " + ido_path + prog + "...")
+def process_prog(prog, ido_path, ido_flag, fix_ugen, build_dir, out_dir, args, recomp):
+    prog_path = ido_path / prog
+    prog_name = prog_path.name
+    c_file_path = build_dir / (prog_name + ".c")
+    out_file_path = name_executable(out_dir, prog_name)
 
-    c_file_path = os.path.join(build_dir, os.path.basename(prog) + "_c.c")
-    out_file_path = os.path.join(out_dir, os.path.basename(prog))
-    if platform.system().startswith("CYGWIN_NT"):
-        out_file_path += ".exe"
-
-    prog_name = os.path.basename(prog)
     conservative_flag = " --conservative " if fix_ugen and prog_name == "ugen" else " "
 
-    if not args.onlylibc:
-        with open(c_file_path, "w") as cFile:
-            call(recomp_path + conservative_flag + ido_path + prog, cFile)
+    emit_translated_c(recomp, conservative_flag, prog_path, c_file_path, args.verbose)
 
-    flags = " -Wno-tautological-compare -fno-strict-aliasing -lm"
+    flags = f"-I. {ido_flag} -Wno-tautological-compare -fno-strict-aliasing -lm"
 
     if platform.system() == "Darwin":
         flags += " -Wno-deprecated-declarations"
-        if "arm" not in platform.processor():
+        if "x86" in platform.processor() and not args.universal:
             flags += " -fno-pie"
     else:
         flags += " -g -no-pie"
@@ -68,64 +91,104 @@ def process_prog(prog, ido_path, ido_flag, fix_ugen, build_dir, out_dir, args, r
     if args.O2:
         flags += " -O2"
 
-    call("gcc libc_impl.c " + c_file_path + " -o " + out_file_path + flags + ido_flag)
+    if args.universal:
+        cross_bins = []
+        for target in MACOS_TARGETS:
+            cross_dir = build_dir / target
+            cross_dir.mkdir(parents=True, exist_ok=True)
+            out = name_executable(cross_dir, prog_name)
+            cross_bins.append(str(out))
 
+            f = f"{flags} -target {target}"
+            if 'x86' in target:
+                f += ' -fno-pie'
+            
+            compile_translated_c(c_file_path, 'libc_impl.c', out, f, args.verbose)
+
+        artifacts = " ".join(cross_bins)
+        stitch_artifacts(out_file_path, artifacts, args.verbose)
+
+    else:
+        compile_translated_c(c_file_path, 'libc_impl.c', out_file_path, flags, args.verbose)
+    
     return
 
-def main(args):
-    ido_path = args.ido_path
-    if ido_path[len(ido_path)-1] == "/":
-        ido_path = ido_path[:len(ido_path)-1]
+def name_executable(location, name):
+    if platform.system().startswith("CYGWIN_NT"):
+        return location / (name + ".exe")
+    else:
+        return location / name
 
-    ido_dir = ido_path.split(os.path.sep)[-1]
+def build_recompiler(in_dir, v):
+    opt = "-O2"
+    capstone = "`pkg-config --cflags --libs capstone`"
+    flags = "-Wno-switch"
+
+    if platform.system() == "Darwin":
+        flags += " -std=c++11"
+    
+    recomp = name_executable(in_dir, "recomp")
+
+    print_step('C++','recomp.cpp',recomp)
+    call(f"g++ recomp.cpp -o {recomp} {opt} {flags} {capstone}", verbose=v)
+
+    return recomp
+
+def emit_translated_c(recomp, flags, idoprog, output_path, v):
+    print_step('RECOMP', idoprog, output_path)
+    with open(output_path, 'w') as cFile:
+        call(f"{recomp} {flags} {idoprog}", cFile, verbose=v)
+
+def compile_translated_c(c_file, libc, out, flags, v):
+    print_step('CC', c_file, out)
+    call(f"gcc {libc} {c_file} -o {out} {flags}", verbose=v)
+
+def stitch_artifacts(out, artifacts, v):
+    print_step('LIPO', artifacts, out, rev=True)
+    call(f'lipo -create -output {out} {artifacts}', verbose=v)
+
+
+def main(args):
+    ido_path = Path(args.ido_path)
+
+    ido_dir = ido_path.parts[-1]
     if "7.1" in ido_dir:
         print("Detected IDO version 7.1")
-        ido_flag = " -DIDO71"
+        ido_flag = "-DIDO71"
         fix_ugen = False
-        build_dir = "build7.1"
+        build_dir = Path("build7.1")
         bins = BINS["7.1"]
     elif "5.3" in ido_dir:
         print("Detected IDO version 5.3")
-        ido_flag = " -DIDO53"
+        ido_flag = "-DIDO53"
         fix_ugen = True
-        build_dir = "build5.3"
+        build_dir = Path("build5.3")
         bins = BINS["5.3"]
     else:
         sys.exit("Unsupported ido dir: " + ido_dir)
 
     if args.multhreading and args.O2:
         print("WARNING: -O2 and -multhreading used together")
-
-    if not os.path.exists(build_dir):
-        os.mkdir(build_dir)
-    shutil.copy("header.h", build_dir)
-    shutil.copy("libc_impl.h", build_dir)
-    shutil.copy("helpers.h", build_dir)
     
-    out_dir = os.path.join(build_dir, "out")
-    if not os.path.exists(out_dir):
-        os.mkdir(out_dir)
+    if args.universal and platform.system() != "Darwin":
+        sys.exit("'-universal' only supported on macOS")
 
-    std_flag = ""
-    if platform.system() == "Darwin":
-        std_flag = " -std=c++11"
-
-    recomp_path = os.path.join(build_dir, "recomp")
-    if platform.system().startswith("CYGWIN_NT"):
-        recomp_path += ".exe"
+    if args.nocolor:
+        COLORS.disable()
     
-    capstone = " `pkg-config --cflags --libs capstone` "
-    recomp_flags = " -Wno-switch "
-    call("g++ recomp.cpp -o " + recomp_path + " -O2 " + std_flag + recomp_flags + capstone)
+    out_dir = build_dir / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    recomp = build_recompiler(build_dir, args.verbose)
     
     threads = []
     for prog in bins:
         if args.multhreading:
-            t = threading.Thread(target=process_prog, args=(prog, ido_path, ido_flag, fix_ugen, build_dir, out_dir, args, recomp_path))
+            t = threading.Thread(target=process_prog, args=(prog, ido_path, ido_flag, fix_ugen, build_dir, out_dir, args, recomp))
             threads.append(t)
             t.start()
         else:
-            process_prog(prog, ido_path, ido_flag, fix_ugen, build_dir, out_dir, args, recomp_path)
+            process_prog(prog, ido_path, ido_flag, fix_ugen, build_dir, out_dir, args, recomp)
     
     if args.multhreading:
         for t in threads:
@@ -137,7 +200,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Static ido recompilation build utility")
     parser.add_argument("ido_path", help="Path to ido")
     parser.add_argument("-O2", help="Build binaries with -O2", action='store_true')
-    parser.add_argument("-onlylibc", help="Builds libc_impl.c only", action='store_true')
     parser.add_argument("-multhreading", help="Enables multi threading (deprecated with O2)", action='store_true')
+    parser.add_argument("-universal", help="Create universal ARM and x86_64 binaries on macOS", action='store_true')
+    parser.add_argument("-verbose", help="Print detailed build commands", action='store_true')
+    parser.add_argument("-nocolor", help="Disable colored printing", action='store_true')
     rgs = parser.parse_args()
     main(rgs)

--- a/build.py
+++ b/build.py
@@ -149,20 +149,21 @@ def stitch_artifacts(out, artifacts, v):
 
 
 def main(args):
-    ido_path = Path(args.ido_path)
+    build_base = Path("build")
 
+    ido_path = Path(args.ido_path)
     ido_dir = ido_path.parts[-1]
     if "7.1" in ido_dir:
         print("Detected IDO version 7.1")
         ido_flag = "-DIDO71"
         fix_ugen = False
-        build_dir = Path("build7.1")
+        build_dir = build_base / "7.1"
         bins = BINS["7.1"]
     elif "5.3" in ido_dir:
         print("Detected IDO version 5.3")
         ido_flag = "-DIDO53"
         fix_ugen = True
-        build_dir = Path("build5.3")
+        build_dir = build_base / "5.3"
         bins = BINS["5.3"]
     else:
         sys.exit("Unsupported ido dir: " + ido_dir)
@@ -179,7 +180,7 @@ def main(args):
     out_dir = build_dir / "out"
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    recomp = build_recompiler(build_dir, args.verbose)
+    recomp = build_recompiler(build_base, args.verbose)
     
     threads = []
     for prog in bins:

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -988,6 +988,30 @@ uint32_t wrapper_strtoul(uint8_t *mem, uint32_t nptr_addr, uint32_t endptr_addr,
     return res;
 }
 
+uint64_t wrapper_strtoll(uint8_t *mem, uint32_t nptr_addr, uint32_t endptr_addr, int base) {
+    STRING(nptr)
+    char *endptr = NULL;
+    uint64_t res = strtoll(nptr, endptr_addr != 0 ? &endptr : NULL, base);
+
+    if(endptr != NULL) {
+        MEM_U32(endptr_addr) = nptr_addr + (uint32_t)(endptr - nptr);
+    }
+
+    return res;
+}
+
+uint64_t wrapper_strtoull(uint8_t *mem, uint32_t nptr_addr, uint32_t endptr_addr, int base) {
+    STRING(nptr)
+    char *endptr = NULL;
+    uint64_t res = strtoull(nptr, endptr_addr != 0 ? &endptr : NULL, base);
+
+    if(endptr != NULL) {
+        MEM_U32(endptr_addr) = nptr_addr + (uint32_t)(endptr - nptr);
+    }
+
+    return res;
+}
+
 double wrapper_strtod(uint8_t *mem, uint32_t nptr_addr, uint32_t endptr_addr) {
     STRING(nptr)
     char *endptr = NULL;

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -1336,7 +1336,7 @@ int wrapper_ftell(uint8_t *mem, uint32_t fp_addr) {
     return res;
 }
 
-int wrapper_rewind(uint8_t *mem, uint32_t fp_addr) {
+void wrapper_rewind(uint8_t *mem, uint32_t fp_addr) {
     (void)wrapper_fseek(mem, fp_addr, 0, SEEK_SET);
     struct FILE_irix *f = (struct FILE_irix *)&MEM_U32(fp_addr);
     f->_flag &= ~IOERR;
@@ -1787,6 +1787,7 @@ int wrapper_setvbuf(uint8_t *mem, uint32_t fp_addr, uint32_t buf_addr, int mode,
     f->_ptr_addr = buf_addr;
     f->_cnt = 0;
     bufendtab[(fp_addr - IOB_ADDR) / sizeof(struct FILE_irix)] = size;
+    return 0;
 }
 
 int wrapper___semgetc(uint8_t *mem, uint32_t fp_addr) {

--- a/libc_impl.h
+++ b/libc_impl.h
@@ -49,7 +49,7 @@ uint32_t wrapper_freopen(uint8_t *mem, uint32_t path_addr, uint32_t mode_addr, u
 int wrapper_fclose(uint8_t *mem, uint32_t fp_addr);
 int wrapper_fflush(uint8_t *mem, uint32_t fp_addr);
 int wrapper_ftell(uint8_t *mem, uint32_t fp_addr);
-int wrapper_rewind(uint8_t *mem, uint32_t fp_addr);
+void wrapper_rewind(uint8_t *mem, uint32_t fp_addr);
 int wrapper_fseek(uint8_t *mem, uint32_t fp_addr, int offset, int origin);
 int wrapper_lseek(uint8_t *mem, int fd, int offset, int whence);
 int wrapper_dup(uint8_t *mem, int fd);

--- a/libc_impl.h
+++ b/libc_impl.h
@@ -31,6 +31,8 @@ int wrapper_atol(uint8_t *mem, uint32_t nptr_addr);
 double wrapper_atof(uint8_t *mem, uint32_t nptr_addr);
 int wrapper_strtol(uint8_t *mem, uint32_t nptr_addr, uint32_t endptr_addr, int base);
 uint32_t wrapper_strtoul(uint8_t *mem, uint32_t nptr_addr, uint32_t endptr_addr, int base);
+uint64_t wrapper_strtoll(uint8_t *mem, uint32_t nptr_addr, uint32_t endptr_addr, int base);
+uint64_t wrapper_strtoull(uint8_t *mem, uint32_t nptr_addr, uint32_t endptr_addr, int base);
 double wrapper_strtod(uint8_t *mem, uint32_t nptr_addr, uint32_t endptr_addr);
 uint32_t wrapper_strchr(uint8_t *mem, uint32_t str_addr, int c);
 uint32_t wrapper_strrchr(uint8_t *mem, uint32_t str_addr, int c);

--- a/recomp.cpp
+++ b/recomp.cpp
@@ -145,6 +145,8 @@ static const struct {
     {"atof", "dp"},
     {"strtol", "ippi"},
     {"strtoul", "uppi"},
+    {"strtoll", "lppi"},
+    {"strtoull", "jppi"},
     {"strtod", "dpp"},
     {"strchr", "ppi"},
     {"strrchr", "ppi"},

--- a/recomp.cpp
+++ b/recomp.cpp
@@ -4,12 +4,13 @@
 #include <string.h>
 #include <inttypes.h>
 
+#include <algorithm>
 #include <map>
 #include <set>
 #include <vector>
 #include <string>
 
-#include <capstone/capstone.h>
+#include <capstone.h>
 
 #include "elf.h"
 
@@ -19,14 +20,7 @@
 #define TRACE 0
 #endif
 
-#ifndef ugen53
-#define ugen53 0
-#endif
-
 #define LABELS_64_BIT 1
-
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 #define u32be(x) (uint32_t)(((x & 0xff) << 24) + ((x & 0xff00) << 8) + ((x & 0xff0000) >> 8) + ((uint32_t)(x) >> 24))
 #define u16be(x) (uint16_t)(((x & 0xff) << 8) + ((x & 0xff00) >> 8))
@@ -76,6 +70,8 @@ struct Function {
     bool v0_in;
     bool referenced_by_function_pointer;
 };
+
+static bool conservative;
 
 static csh handle;
 
@@ -166,7 +162,7 @@ static const struct {
     {"freopen", "pppp"},
     {"fclose", "ip"},
     {"ftell", "ip"},
-    {"rewind", "ip"},
+    {"rewind", "vp"},
     {"fseek", "ipii"},
     {"lseek", "iiii"},
     {"fflush", "ip"},
@@ -282,24 +278,31 @@ static const struct {
 static void disassemble(void) {
     csh handle;
     cs_insn *disasm;
-    static size_t disasm_size;
+    size_t disasm_size = 0;
     assert(cs_open(CS_ARCH_MIPS, (cs_mode)(CS_MODE_MIPS64 | CS_MODE_BIG_ENDIAN), &handle) == CS_ERR_OK);
     cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
-    disasm_size = cs_disasm(handle, text_section, text_section_len, text_vaddr, 0, &disasm);
-    for (size_t i = 0; i < disasm_size; i++) {
-        insns.push_back(Insn());
-        Insn& insn = insns.back();
-        insn.id = disasm[i].id;
-        insn.mnemonic = disasm[i].mnemonic;
-        insn.op_str = disasm[i].op_str;
-        if (disasm[i].detail != nullptr && disasm[i].detail->mips.op_count > 0) {
-            insn.op_count = disasm[i].detail->mips.op_count;
-            memcpy(insn.operands, disasm[i].detail->mips.operands, sizeof(insn.operands));
+    insns.reserve(1 + text_section_len / sizeof(uint32_t)); // +1 for dummy instruction
+    while (text_section_len > disasm_size * sizeof(uint32_t)) {
+        size_t disasm_len = disasm_size * sizeof(uint32_t);
+        size_t remaining = text_section_len - disasm_len;
+        size_t current_len = std::min<size_t>(remaining, 1024);
+        size_t cur_disasm_size = cs_disasm(handle, &text_section[disasm_len], current_len, text_vaddr + disasm_len, 0, &disasm);
+        disasm_size += cur_disasm_size;
+        for (size_t i = 0; i < cur_disasm_size; i++) {
+            insns.push_back(Insn());
+            Insn& insn = insns.back();
+            insn.id = disasm[i].id;
+            insn.mnemonic = disasm[i].mnemonic;
+            insn.op_str = disasm[i].op_str;
+            if (disasm[i].detail != nullptr && disasm[i].detail->mips.op_count > 0) {
+                insn.op_count = disasm[i].detail->mips.op_count;
+                memcpy(insn.operands, disasm[i].detail->mips.operands, sizeof(insn.operands));
+            }
+            insn.is_jump = cs_insn_group(handle, &disasm[i], MIPS_GRP_JUMP) || insn.id == MIPS_INS_JAL || insn.id == MIPS_INS_BAL || insn.id == MIPS_INS_JALR;
+            insn.linked_insn = -1;
         }
-        insn.is_jump = cs_insn_group(handle, &disasm[i], MIPS_GRP_JUMP) || insn.id == MIPS_INS_JAL || insn.id == MIPS_INS_BAL || insn.id == MIPS_INS_JALR;
-        insn.linked_insn = -1;
+        cs_free(disasm, cur_disasm_size);
     }
-    cs_free(disasm, disasm_size);
     cs_close(&handle);
 
     {
@@ -336,7 +339,7 @@ static void link_with_lui(int offset, uint32_t reg, int mem_imm)
 #define MAX_LOOKBACK 128
     // don't attempt to compute addresses for zero offset
     // end search after some sane max number of instructions
-    int end_search = MAX(0, offset - MAX_LOOKBACK);
+    int end_search = std::max(0, offset - MAX_LOOKBACK);
     for (int search = offset - 1; search >= end_search; search--) {
         // use an `if` instead of `case` block to allow breaking out of the `for` loop
         if (insns[search].id == MIPS_INS_LUI) {
@@ -423,7 +426,7 @@ static void link_with_lui(int offset, uint32_t reg, int mem_imm)
 static void link_with_jalr(int offset)
 {
     // end search after some sane max number of instructions
-    int end_search = MAX(0, offset - MAX_LOOKBACK);
+    int end_search = std::max(0, offset - MAX_LOOKBACK);
     for (int search = offset - 1; search >= end_search; search--) {
         if (insns[search].operands[0].reg == MIPS_REG_T9) {
             if (insns[search].id == MIPS_INS_LW || insns[search].id == MIPS_INS_LI) {
@@ -1636,7 +1639,7 @@ static void dump_instr(int i) {
         printf("++cnt; printf(\"pc=0x%08x%s%s\\n\"); ", text_vaddr + i * 4, symbol_name ? " " : "", symbol_name ? symbol_name : "");
     }
     Insn& insn = insns[i];
-    if (!insn.is_jump && !ugen53) {
+    if (!insn.is_jump && !conservative) {
         switch (insn_to_type(insn)) {
             case TYPE_1S:
                 if (!(insn.f_livein & map_reg(insn.operands[0].reg))) {
@@ -2340,16 +2343,16 @@ static void dump_c(void) {
     uint32_t max_addr = 0;
 
     if (data_section_len > 0) {
-        min_addr = MIN(min_addr, data_vaddr);
-        max_addr = MAX(max_addr, data_vaddr + data_section_len);
+        min_addr = std::min(min_addr, data_vaddr);
+        max_addr = std::max(max_addr, data_vaddr + data_section_len);
     }
     if (rodata_section_len > 0) {
-        min_addr = MIN(min_addr, rodata_vaddr);
-        max_addr = MAX(max_addr, rodata_vaddr + rodata_section_len);
+        min_addr = std::min(min_addr, rodata_vaddr);
+        max_addr = std::max(max_addr, rodata_vaddr + rodata_section_len);
     }
     if (bss_section_len) {
-        min_addr = MIN(min_addr, bss_vaddr);
-        max_addr = MAX(max_addr, bss_vaddr + bss_section_len);
+        min_addr = std::min(min_addr, bss_vaddr);
+        max_addr = std::max(max_addr, bss_vaddr + bss_section_len);
     }
 
     min_addr = min_addr & ~0xfff;
@@ -2360,7 +2363,7 @@ static void dump_c(void) {
     stack_bottom -= 16; // for main's stack frame
 
     printf("#include \"header.h\"\n");
-    if (ugen53) {
+    if (conservative) {
         printf("static uint32_t s0, s1, s2, s3, s4, s5, s6, s7, fp;\n");
     }
     printf("static const uint32_t rodata[] = {\n");
@@ -2488,7 +2491,7 @@ static void dump_c(void) {
         dump_function_signature(f, start_addr);
         printf(" {\n");
         printf("const uint32_t zero = 0;\n");
-        if (!ugen53) {
+        if (!conservative) {
             printf("uint32_t at = 0, v1 = 0, t0 = 0, t1 = 0, t2 = 0,\n");
             printf("t3 = 0, t4 = 0, t5 = 0, t6 = 0, t7 = 0, s0 = 0, s1 = 0, s2 = 0, s3 = 0, s4 = 0, s5 = 0,\n");
             printf("s6 = 0, s7 = 0, t8 = 0, t9 = 0, gp = 0, fp = 0, s8 = 0, ra = 0;\n");
@@ -2913,8 +2916,14 @@ size_t read_file(const char *file_name, uint8_t **data) {
 }
 
 int main(int argc, char *argv[]) {
+    const char *filename = argv[1];
+    if (strcmp(filename, "--conservative") == 0) {
+        conservative = true;
+        filename = argv[2];
+    }
+
     uint8_t *data;
-    size_t len = read_file(argv[1], &data);
+    size_t len = read_file(filename, &data);
     parse_elf(data, len);
     assert(cs_open(CS_ARCH_MIPS, (cs_mode)(CS_MODE_MIPS64 | CS_MODE_BIG_ENDIAN), &handle) == CS_ERR_OK);
     cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);


### PR DESCRIPTION
Apple uses 16KB page sizes on ARM instead of the typical 4KB. 

The main change I made was page aligning the `sbrk` increment. There's probably a better way to this, but since the main use of `sbrk` seems to be for `malloc`, and the minimum allocated block size is 0x10000, rounding up to the next page size doesn't seem to waste huge amounts of memory.

-----
Tested on
* macOS (arm)
  * sm64 [5.3]
  * oot [7.1 and 5.3]
* Ubuntu (arm)
  * sm64

If anyone else wants to test on x86 feel free!