### PR TITLE
Fix `double` handling in register usage and fix `wrapper_times`

### DIFF
--- a/build.py
+++ b/build.py
@@ -63,6 +63,8 @@ def process_prog(prog, ido_path, ido_flag, build_dir, out_dir, args, recomp_path
     if args.O2:
         flags += " -O2"
 
+    flags += " -Wno-deprecated-declarations"
+
     call("gcc libc_impl.c " + c_file_path + " -o " + out_file_path + flags + ido_flag)
 
     return

--- a/build.py
+++ b/build.py
@@ -98,7 +98,7 @@ def main(args):
     shutil.copy("header.h", build_dir)
     shutil.copy("libc_impl.h", build_dir)
     shutil.copy("helpers.h", build_dir)
-    
+
     out_dir = os.path.join(build_dir, "out")
     if not os.path.exists(out_dir):
         os.mkdir(out_dir)
@@ -111,7 +111,7 @@ def main(args):
     if platform.system().startswith("CYGWIN_NT"):
         recomp_path += ".exe"
     call("g++ recomp.cpp -o " + recomp_path + " -g -lcapstone" + std_flag + ugen_flag)
-    
+
     threads = []
     for prog in bins:
         if args.multhreading:
@@ -120,7 +120,7 @@ def main(args):
             t.start()
         else:
             process_prog(prog, ido_path, ido_flag, build_dir, out_dir, args, recomp_path)
-    
+
     if args.multhreading:
         for t in threads:
             t.join()

--- a/header.h
+++ b/header.h
@@ -22,21 +22,3 @@ static union FloatReg f0 = {{0, 0}}, f2 = {{0, 0}}, f4 = {{0, 0}}, f6 = {{0, 0}}
 f10 = {{0, 0}}, f12 = {{0, 0}}, f14 = {{0, 0}}, f16 = {{0, 0}}, f18 = {{0, 0}}, f20 = {{0, 0}},
 f22 = {{0, 0}}, f24 = {{0, 0}}, f26 = {{0, 0}}, f28 = {{0, 0}}, f30 = {{0, 0}};
 static uint32_t fcsr = 1;
-
-static inline double double_from_FloatReg(union FloatReg floatreg) {
-    uint64_t val;
-
-    val = floatreg.w[1];
-    val <<= 32;
-    val |= floatreg.w[0];
-    return *(double*)&val;
-}
-static inline union FloatReg FloatReg_from_double(double d) {
-    uint64_t val = *(uint64_t*)&d;
-    union FloatReg floatreg;
-
-    floatreg.w[0] = (val) & 0xFFFFFFFF;
-    floatreg.w[1] = (val >> 32) & 0xFFFFFFFF;
-
-    return floatreg;
-}

--- a/header.h
+++ b/header.h
@@ -13,12 +13,6 @@
 #define RM_RP 2
 #define RM_RM 3
 
-union FloatReg {
-    float f[2];
-    uint32_t w[2];
-    double d;
-};
-
 #define cvt_w_d(f) \
     ((fcsr & RM_RZ) ? ((isnan(f) || f <= -2147483649.0 || f >= 2147483648.0) ? (fcsr |= 0x40, 2147483647) : (int)f) : (assert(0), 0))
 
@@ -28,3 +22,21 @@ static union FloatReg f0 = {{0, 0}}, f2 = {{0, 0}}, f4 = {{0, 0}}, f6 = {{0, 0}}
 f10 = {{0, 0}}, f12 = {{0, 0}}, f14 = {{0, 0}}, f16 = {{0, 0}}, f18 = {{0, 0}}, f20 = {{0, 0}},
 f22 = {{0, 0}}, f24 = {{0, 0}}, f26 = {{0, 0}}, f28 = {{0, 0}}, f30 = {{0, 0}};
 static uint32_t fcsr = 1;
+
+static inline double double_from_FloatReg(union FloatReg floatreg) {
+    uint64_t val;
+
+    val = floatreg.w[1];
+    val <<= 32;
+    val |= floatreg.w[0];
+    return *(double*)&val;
+}
+static inline union FloatReg FloatReg_from_double(double d) {
+    uint64_t val = *(uint64_t*)&d;
+    union FloatReg floatreg;
+
+    floatreg.w[0] = (val) & 0xFFFFFFFF;
+    floatreg.w[1] = (val >> 32) & 0xFFFFFFFF;
+
+    return floatreg;
+}

--- a/helpers.h
+++ b/helpers.h
@@ -3,13 +3,25 @@
 
 #include <stdint.h>
 
-#define MEM_F64(a) (*(double*)(mem + a))
-#define MEM_F32(a) (*(float*)(mem + a))
 #define MEM_U32(a) (*(uint32_t *)(mem + a))
 #define MEM_S32(a) (*(int32_t *)(mem + a))
 #define MEM_U16(a) (*(uint16_t *)(mem + ((a) ^ 2)))
 #define MEM_S16(a) (*(int16_t *)(mem + ((a) ^ 2)))
 #define MEM_U8(a) (*(uint8_t *)(mem + ((a) ^ 3)))
 #define MEM_S8(a) (*(int8_t *)(mem + ((a) ^ 3)))
+
+#define MEM_F32(a) (*(float *)(mem + a))
+
+static inline double MEM_F64_aux(uint8_t *mem, uint32_t a) {
+    uint64_t val;
+
+    val = MEM_U32(a);
+    val <<= 32;
+    val |= MEM_U32(a + 4);
+    return *(double*)&val;
+}
+
+
+#define MEM_F64(a) (MEM_F64_aux(mem, a))
 
 #endif

--- a/helpers.h
+++ b/helpers.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#define MEM_F64(a) (*(double*)(mem + a))
+#define MEM_F32(a) (*(float*)(mem + a))
 #define MEM_U32(a) (*(uint32_t *)(mem + a))
 #define MEM_S32(a) (*(int32_t *)(mem + a))
 #define MEM_U16(a) (*(uint16_t *)(mem + ((a) ^ 2)))

--- a/helpers.h
+++ b/helpers.h
@@ -3,25 +3,13 @@
 
 #include <stdint.h>
 
+#define MEM_F64(a) (double_from_memory(mem, a))
+#define MEM_F32(a) (*(float *)(mem + a))
 #define MEM_U32(a) (*(uint32_t *)(mem + a))
 #define MEM_S32(a) (*(int32_t *)(mem + a))
 #define MEM_U16(a) (*(uint16_t *)(mem + ((a) ^ 2)))
 #define MEM_S16(a) (*(int16_t *)(mem + ((a) ^ 2)))
 #define MEM_U8(a) (*(uint8_t *)(mem + ((a) ^ 3)))
 #define MEM_S8(a) (*(int8_t *)(mem + ((a) ^ 3)))
-
-#define MEM_F32(a) (*(float *)(mem + a))
-
-static inline double MEM_F64_aux(uint8_t *mem, uint32_t a) {
-    uint64_t val;
-
-    val = MEM_U32(a);
-    val <<= 32;
-    val |= MEM_U32(a + 4);
-    return *(double*)&val;
-}
-
-
-#define MEM_F64(a) (MEM_F64_aux(mem, a))
 
 #endif

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -2588,55 +2588,37 @@ void wrapper___assert(uint8_t *mem, uint32_t assertion_addr, uint32_t file_addr,
     __assert(assertion, file, line);
 }
 
-void instructrionwrapper_set_to_dr_from_double(union FloatReg *dst, double src) {
-    *dst = FloatReg_from_double(src);
+union host_doubleword {
+    uint64_t ww;
+    double d;
+};
+
+union FloatReg FloatReg_from_double(double d) {
+    union host_doubleword val;
+    union FloatReg floatreg;
+
+    val.d = d;
+
+    floatreg.w[0] = val.ww & 0xFFFFFFFF;
+    floatreg.w[1] = (val.ww >> 32) & 0xFFFFFFFF;
+
+    return floatreg;
 }
 
-void instructrionwrapper_add_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
-    double d_fs = double_from_FloatReg(fs);
-    double d_ft = double_from_FloatReg(ft);
-    double result;
+double double_from_FloatReg(union FloatReg floatreg) {
+    union host_doubleword val;
 
-    result = d_fs + d_ft;
-
-    *dst = FloatReg_from_double(result);
+    val.ww = floatreg.w[1];
+    val.ww <<= 32;
+    val.ww |= floatreg.w[0];
+    return val.d;
 }
 
-void instructrionwrapper_sub_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
-    double d_fs = double_from_FloatReg(fs);
-    double d_ft = double_from_FloatReg(ft);
-    double result;
+double double_from_memory(uint8_t *mem, uint32_t address) {
+    union host_doubleword val;
 
-    result = d_fs - d_ft;
-
-    *dst = FloatReg_from_double(result);
-}
-
-void instructrionwrapper_mul_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
-    double d_fs = double_from_FloatReg(fs);
-    double d_ft = double_from_FloatReg(ft);
-    double result;
-
-    result = d_fs * d_ft;
-
-    *dst = FloatReg_from_double(result);
-}
-
-void instructrionwrapper_div_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
-    double d_fs = double_from_FloatReg(fs);
-    double d_ft = double_from_FloatReg(ft);
-    double result;
-
-    result = d_fs / d_ft;
-
-    *dst = FloatReg_from_double(result);
-}
-
-void instructrionwrapper_neg_d(union FloatReg *dst, union FloatReg fs) {
-    double d_fs = double_from_FloatReg(fs);
-    double result;
-
-    result = -d_fs;
-
-    *dst = FloatReg_from_double(result);
+    val.ww = MEM_U32(address);
+    val.ww <<= 32;
+    val.ww |= MEM_U32(address + 4);
+    return val.d;
 }

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -33,6 +33,7 @@
 
 #include "libc_impl.h"
 #include "helpers.h"
+#include "header.h"
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
@@ -2585,4 +2586,57 @@ void wrapper___assert(uint8_t *mem, uint32_t assertion_addr, uint32_t file_addr,
     STRING(assertion)
     STRING(file)
     __assert(assertion, file, line);
+}
+
+void instructrionwrapper_set_to_dr_from_double(union FloatReg *dst, double src) {
+    *dst = FloatReg_from_double(src);
+}
+
+void instructrionwrapper_add_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
+    double d_fs = double_from_FloatReg(fs);
+    double d_ft = double_from_FloatReg(ft);
+    double result;
+
+    result = d_fs + d_ft;
+
+    *dst = FloatReg_from_double(result);
+}
+
+void instructrionwrapper_sub_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
+    double d_fs = double_from_FloatReg(fs);
+    double d_ft = double_from_FloatReg(ft);
+    double result;
+
+    result = d_fs - d_ft;
+
+    *dst = FloatReg_from_double(result);
+}
+
+void instructrionwrapper_mul_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
+    double d_fs = double_from_FloatReg(fs);
+    double d_ft = double_from_FloatReg(ft);
+    double result;
+
+    result = d_fs * d_ft;
+
+    *dst = FloatReg_from_double(result);
+}
+
+void instructrionwrapper_div_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
+    double d_fs = double_from_FloatReg(fs);
+    double d_ft = double_from_FloatReg(ft);
+    double result;
+
+    result = d_fs / d_ft;
+
+    *dst = FloatReg_from_double(result);
+}
+
+void instructrionwrapper_neg_d(union FloatReg *dst, union FloatReg fs) {
+    double d_fs = double_from_FloatReg(fs);
+    double result;
+
+    result = -d_fs;
+
+    *dst = FloatReg_from_double(result);
 }

--- a/libc_impl.h
+++ b/libc_impl.h
@@ -1,4 +1,13 @@
+#ifndef LIBC_IMPL_H
+#define LIBC_IMPL_H
+
 #include <stdint.h>
+
+union FloatReg {
+    float f[2];
+    uint32_t w[2];
+    //double d;
+};
 
 void mmap_initial_data_range(uint8_t *mem, uint32_t start, uint32_t end);
 void setup_libc_data(uint8_t *mem);
@@ -161,3 +170,12 @@ uint32_t wrapper_qsort(uint8_t *mem, uint32_t base_addr, uint32_t num, uint32_t 
 uint32_t wrapper_regcmp(uint8_t *mem, uint32_t string1_addr, uint32_t sp);
 uint32_t wrapper_regex(uint8_t *mem, uint32_t re_addr, uint32_t subject_addr, uint32_t sp);
 void wrapper___assert(uint8_t *mem, uint32_t assertion_addr, uint32_t file_addr, int line);
+
+void instructrionwrapper_set_to_dr_from_double(union FloatReg *dst, double src);
+void instructrionwrapper_add_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
+void instructrionwrapper_sub_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
+void instructrionwrapper_mul_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
+void instructrionwrapper_div_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
+void instructrionwrapper_neg_d(union FloatReg *dst, union FloatReg fs);
+
+#endif

--- a/libc_impl.h
+++ b/libc_impl.h
@@ -171,11 +171,8 @@ uint32_t wrapper_regcmp(uint8_t *mem, uint32_t string1_addr, uint32_t sp);
 uint32_t wrapper_regex(uint8_t *mem, uint32_t re_addr, uint32_t subject_addr, uint32_t sp);
 void wrapper___assert(uint8_t *mem, uint32_t assertion_addr, uint32_t file_addr, int line);
 
-void instructrionwrapper_set_to_dr_from_double(union FloatReg *dst, double src);
-void instructrionwrapper_add_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
-void instructrionwrapper_sub_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
-void instructrionwrapper_mul_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
-void instructrionwrapper_div_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
-void instructrionwrapper_neg_d(union FloatReg *dst, union FloatReg fs);
+union FloatReg FloatReg_from_double(double d);
+double double_from_FloatReg(union FloatReg floatreg);
+double double_from_memory(uint8_t *mem, uint32_t address);
 
 #endif

--- a/recomp.cpp
+++ b/recomp.cpp
@@ -2002,7 +2002,7 @@ static void dump_instr(int i) {
                     printf("%s = (uint32_t)(temp64 >> 32);\n", r(MIPS_REG_V0));
                     printf("%s = (uint32_t)temp64;\n", r(MIPS_REG_V1));
                 } else if (ret_type == 'd') {
-                    printf("%s = FloatReg_from_double(temp64);\n", dr(MIPS_REG_F0));
+                    printf("%s = FloatReg_from_double(tempf64);\n", dr(MIPS_REG_F0));
                 }
                 if (!name.empty()) {
                     //printf("printf(\"%s %%x\\n\", %s);\n", name.c_str(), r(MIPS_REG_A0));

--- a/recomp.cpp
+++ b/recomp.cpp
@@ -1687,8 +1687,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "add.s") {
                 printf("%s = %s + %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "add.d") {
-                //printf("%s = %s + %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
-                printf("instructrionwrapper_add_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("%s = FloatReg_from_double(double_from_FloatReg(%s) + double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 printf("%s = %s + %s;\n", r(insn.operands[0].reg), r(insn.operands[1].reg), r(insn.operands[2].reg));
             }
@@ -1798,9 +1797,9 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "cvt.s.w") {
                 printf("%s = (int)%s;\n", fr(insn.operands[0].reg), wr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.d.w") {
-                printf("instructrionwrapper_set_to_dr_from_double(&%s, (int)%s);\n", dr(insn.operands[0].reg), wr(insn.operands[1].reg));
+                printf("%s = FloatReg_from_double((int)%s);\n", dr(insn.operands[0].reg), wr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.d.s") {
-                printf("instructrionwrapper_set_to_dr_from_double(&%s, %s);\n", dr(insn.operands[0].reg), fr(insn.operands[1].reg));
+                printf("%s = FloatReg_from_double(%s);\n", dr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.s.d") {
                 printf("%s = double_from_FloatReg(%s);\n", fr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.w.d") {
@@ -1825,7 +1824,7 @@ static void dump_instr(int i) {
                 printf("%s = %s / %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "div.d") {
                 assert(insn.op_count == 3);
-                printf("instructrionwrapper_div_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("%s = FloatReg_from_double(double_from_FloatReg(%s) / double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 assert(insn.op_count == 2);
                 printf("lo = (int)%s / (int)%s; ", r(insn.operands[0].reg), r(insn.operands[1].reg));
@@ -1841,7 +1840,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "mov.s") {
                 printf("%s = %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "mov.d") {
-                printf("instructrionwrapper_set_to_dr_from_double(&%s, double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("%s = %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else {
                 goto unimplemented;
             }
@@ -1850,7 +1849,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "mul.s") {
                 printf("%s = %s * %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "mul.d") {
-                printf("instructrionwrapper_mul_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("%s = FloatReg_from_double(double_from_FloatReg(%s) * double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 goto unimplemented;
             }
@@ -1859,7 +1858,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "neg.s") {
                 printf("%s = -%s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "neg.d") {
-                printf("instructrionwrapper_neg_d(&%s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("%s = FloatReg_from_double(-double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else {
                 printf("%s = -%s;\n", r(insn.operands[0].reg), r(insn.operands[1].reg));
             }
@@ -1868,7 +1867,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "sub.s") {
                 printf("%s = %s - %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "sub.d") {
-                printf("instructrionwrapper_sub_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("%s = FloatReg_from_double(double_from_FloatReg(%s) - double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 goto unimplemented;
             }
@@ -2004,7 +2003,7 @@ static void dump_instr(int i) {
                     printf("%s = (uint32_t)(temp64 >> 32);\n", r(MIPS_REG_V0));
                     printf("%s = (uint32_t)temp64;\n", r(MIPS_REG_V1));
                 } else if (ret_type == 'd') {
-                    printf("instructrionwrapper_set_to_dr_from_double(&%s, temp64);\n", dr(MIPS_REG_F0));
+                    printf("%s = FloatReg_from_double(temp64);\n", dr(MIPS_REG_F0));
                 }
                 if (!name.empty()) {
                     //printf("printf(\"%s %%x\\n\", %s);\n", name.c_str(), r(MIPS_REG_A0));

--- a/recomp.cpp
+++ b/recomp.cpp
@@ -1577,22 +1577,22 @@ static const char *fr(uint32_t reg) {
 
 static const char *dr(uint32_t reg) {
     static const char *regs[] = {
-        "f0.d",
-        "f2.d",
-        "f4.d",
-        "f6.d",
-        "f8.d",
-        "f10.d",
-        "f12.d",
-        "f14.d",
-        "f16.d",
-        "f18.d",
-        "f20.d",
-        "f22.d",
-        "f24.d",
-        "f26.d",
-        "f28.d",
-        "f30.d"
+        "f0",
+        "f2",
+        "f4",
+        "f6",
+        "f8",
+        "f10",
+        "f12",
+        "f14",
+        "f16",
+        "f18",
+        "f20",
+        "f22",
+        "f24",
+        "f26",
+        "f28",
+        "f30"
     };
     assert(reg >= MIPS_REG_F0 && reg <= MIPS_REG_F31 && (reg - MIPS_REG_F0) % 2 == 0);
     return regs[(reg - MIPS_REG_F0) / 2];
@@ -1687,7 +1687,8 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "add.s") {
                 printf("%s = %s + %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "add.d") {
-                printf("%s = %s + %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                //printf("%s = %s + %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("instructrionwrapper_add_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 printf("%s = %s + %s;\n", r(insn.operands[0].reg), r(insn.operands[1].reg), r(insn.operands[2].reg));
             }
@@ -1786,24 +1787,24 @@ static void dump_instr(int i) {
             } else if (insn.mnemonic == "c.eq.s") {
                 printf("cf = %s == %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "c.lt.d") {
-                printf("cf = %s < %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("cf = double_from_FloatReg(%s) < double_from_FloatReg(%s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else if (insn.mnemonic == "c.le.d") {
-                printf("cf = %s <= %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("cf = double_from_FloatReg(%s) <= double_from_FloatReg(%s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else if (insn.mnemonic == "c.eq.d") {
-                printf("cf = %s == %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("cf = double_from_FloatReg(%s) == double_from_FloatReg(%s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             }
             break;
         case MIPS_INS_CVT:
             if (insn.mnemonic == "cvt.s.w") {
                 printf("%s = (int)%s;\n", fr(insn.operands[0].reg), wr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.d.w") {
-                printf("%s = (int)%s;\n", dr(insn.operands[0].reg), wr(insn.operands[1].reg));
+                printf("instructrionwrapper_set_to_dr_from_double(&%s, (int)%s);\n", dr(insn.operands[0].reg), wr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.d.s") {
-                printf("%s = %s;\n", dr(insn.operands[0].reg), fr(insn.operands[1].reg));
+                printf("instructrionwrapper_set_to_dr_from_double(&%s, %s);\n", dr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.s.d") {
-                printf("%s = %s;\n", fr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("%s = double_from_FloatReg(%s);\n", fr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.w.d") {
-                printf("%s = cvt_w_d(%s);\n", wr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("%s = cvt_w_d(double_from_FloatReg(%s));\n", wr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.w.s") {
                 printf("%s = cvt_w_s(%s);\n", wr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else {
@@ -1824,7 +1825,7 @@ static void dump_instr(int i) {
                 printf("%s = %s / %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "div.d") {
                 assert(insn.op_count == 3);
-                printf("%s = %s / %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("instructrionwrapper_div_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 assert(insn.op_count == 2);
                 printf("lo = (int)%s / (int)%s; ", r(insn.operands[0].reg), r(insn.operands[1].reg));
@@ -1840,7 +1841,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "mov.s") {
                 printf("%s = %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "mov.d") {
-                printf("%s = %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("instructrionwrapper_set_to_dr_from_double(&%s, double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else {
                 goto unimplemented;
             }
@@ -1849,7 +1850,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "mul.s") {
                 printf("%s = %s * %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "mul.d") {
-                printf("%s = %s * %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("instructrionwrapper_mul_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 goto unimplemented;
             }
@@ -1858,7 +1859,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "neg.s") {
                 printf("%s = -%s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "neg.d") {
-                printf("%s = -%s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("instructrionwrapper_neg_d(&%s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else {
                 printf("%s = -%s;\n", r(insn.operands[0].reg), r(insn.operands[1].reg));
             }
@@ -1867,7 +1868,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "sub.s") {
                 printf("%s = %s - %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "sub.d") {
-                printf("%s = %s - %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("instructrionwrapper_sub_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 goto unimplemented;
             }
@@ -1912,7 +1913,8 @@ static void dump_instr(int i) {
                             printf("%s = ", fr(MIPS_REG_F0));
                             break;
                         case 'd':
-                            printf("%s = ", dr(MIPS_REG_F0));
+                            //printf("%s = ", dr(MIPS_REG_F0));
+                            printf("tempf64 = ");
                             break;
                         case 'l':
                         case 'j':
@@ -1967,7 +1969,7 @@ static void dump_instr(int i) {
                                 ++pos;
                             }
                             if (only_floats_so_far && pos_float < 4) {
-                                printf("%s", dr(MIPS_REG_F12 + pos_float));
+                                printf("double_from_FloatReg(%s)", dr(MIPS_REG_F12 + pos_float));
                                 pos_float += 2;
                             } else if (pos < 4) {
                                 printf("BITCAST_U64_TO_F64(((uint64_t)%s << 32) | (uint64_t)%s)", r(MIPS_REG_A0 + pos), r(MIPS_REG_A0 + pos + 1));
@@ -2001,6 +2003,8 @@ static void dump_instr(int i) {
                 if (ret_type == 'l' || ret_type == 'j') {
                     printf("%s = (uint32_t)(temp64 >> 32);\n", r(MIPS_REG_V0));
                     printf("%s = (uint32_t)temp64;\n", r(MIPS_REG_V1));
+                } else if (ret_type == 'd') {
+                    printf("instructrionwrapper_set_to_dr_from_double(&%s, temp64);\n", dr(MIPS_REG_F0));
                 }
                 if (!name.empty()) {
                     //printf("printf(\"%s %%x\\n\", %s);\n", name.c_str(), r(MIPS_REG_A0));
@@ -2239,7 +2243,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "trunc.w.s") {
                 printf("%s = (int)%s;\n", wr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "trunc.w.d") {
-                printf("%s = (int)%s;\n", wr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("%s = (int)double_from_FloatReg(%s);\n", wr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else {
                 goto unimplemented;
             }
@@ -2499,6 +2503,7 @@ static void dump_c(void) {
         printf("uint32_t lo = 0, hi = 0;\n");
         printf("int cf = 0;\n");
         printf("uint64_t temp64;\n");
+        printf("double tempf64;\n");
         printf("uint32_t fp_dest;\n");
         printf("void *dest;\n");
         if (!f.v0_in) {

--- a/recomp.cpp
+++ b/recomp.cpp
@@ -1912,7 +1912,6 @@ static void dump_instr(int i) {
                             printf("%s = ", fr(MIPS_REG_F0));
                             break;
                         case 'd':
-                            //printf("%s = ", dr(MIPS_REG_F0));
                             printf("tempf64 = ");
                             break;
                         case 'l':


### PR DESCRIPTION
Currently `double`s are stored in big endian in float registers (because that's what the actual instructions are doing). The current approach to handle those doubles in registers is to access them with an union type-pun to read it as a double, but this would yield wrong results when the host machine is not big endian.
To avoid this issue, instead of type-punning the float registers I changed to use two new functions (`FloatReg_from_double` and `double double_from_FloatReg`) which allow to convert back and forth `double`s and `FloatReg`s to the proper endian. I don't really like the names I came up with, so any suggestion is welcome c:

This PR also fixes the `wrapper_times` function to fill the struct pointer passed as a parameter as it is supposed to.